### PR TITLE
support non-ActiveRecord objects in set!/prefactory_add

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.2
+  - 2.2.3
 env:
   - ACTIVE_RECORD_VERSION=4.0.0 RSPEC_VERSION=2.99
   - ACTIVE_RECORD_VERSION=4.0.0

--- a/lib/prefactory/prefactory_lookup.rb
+++ b/lib/prefactory/prefactory_lookup.rb
@@ -5,6 +5,7 @@ class PrefactoryLookup < ActiveRecord::Base
       t.column :key, :string
       t.column :result_class, :string
       t.column :result_id, :integer
+      t.column :result_value, :text
       t.index [:key], :unique => true
     end
   end

--- a/spec/database_setup.rb
+++ b/spec/database_setup.rb
@@ -25,7 +25,7 @@ require 'erb'
 config = YAML.load(ERB.new(File.read(File.dirname(__FILE__) + '/database.yml')).result)
 ActiveRecord::Base.logger = Logger.new(File.dirname(__FILE__) + "/debug.log")
 ActiveRecord::Base.establish_connection(config[ENV['DB'] || 'sqlite3'])
-ActiveRecord::Base.raise_in_transactional_callbacks = true
+ActiveRecord::Base.raise_in_transactional_callbacks = true if ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks)
 
 ActiveRecord::Schema.define(:version => 2) do
   create_table :blogs, :force => true do |t|

--- a/spec/database_setup.rb
+++ b/spec/database_setup.rb
@@ -25,24 +25,25 @@ require 'erb'
 config = YAML.load(ERB.new(File.read(File.dirname(__FILE__) + '/database.yml')).result)
 ActiveRecord::Base.logger = Logger.new(File.dirname(__FILE__) + "/debug.log")
 ActiveRecord::Base.establish_connection(config[ENV['DB'] || 'sqlite3'])
+ActiveRecord::Base.raise_in_transactional_callbacks = true
 
 ActiveRecord::Schema.define(:version => 2) do
   create_table :blogs, :force => true do |t|
     t.column :title, :string
     t.column :counter, :integer
-    t.timestamps
+    t.timestamps :null => false
   end
   create_table :comments, :force => true do |t|
     t.column :blog_id, :integer
     t.column :counter, :integer
     t.column :text, :string
-    t.timestamps
+    t.timestamps :null => false
   end
   create_table :links, :force => true do |t|
     t.column :blog_id, :integer
     t.column :counter, :integer
     t.column :name, :string
-    t.timestamps
+    t.timestamps :null => false
   end
 end
 

--- a/spec/prefactory_spec.rb
+++ b/spec/prefactory_spec.rb
@@ -118,6 +118,15 @@ describe Prefactory do
         expect(some_other_blog.counter).to eq(24)
       end
     end
+    context "when the block returns something that does not respond_to? :id" do
+      before :all do
+        prefactory_add(:freeze_time) { Time.parse('2015-09-13 17:15') }
+      end
+      it do
+        expect(freeze_time).to be_a Time
+        expect(freeze_time).to eq Time.parse('2015-09-13 17:15')
+      end
+    end
     context "when referencing the object within the before-all block" do
       before :all do
         prefactory_add :blog
@@ -198,7 +207,7 @@ describe Prefactory do
         expect(@before_each_exception).to be_present
       end
       it "raises an error in an it-context" do
-        expect { prefactory_add(:comment) }.to raise_error
+        expect { prefactory_add(:comment) }.to raise_error(/can only be used in a before\(:all\)/)
       end
       it "works in a before-all context" do
         expect(prefactory(:blog)).to be_present

--- a/spec/prefactory_spec.rb
+++ b/spec/prefactory_spec.rb
@@ -118,7 +118,7 @@ describe Prefactory do
         expect(some_other_blog.counter).to eq(24)
       end
     end
-    context "when the block returns something that does not respond_to? :id" do
+    context 'when the block returns something that does not respond_to? :id' do
       before :all do
         prefactory_add(:freeze_time) { Time.parse('2015-09-13 17:15') }
       end


### PR DESCRIPTION
Allow non-AR objects in `set!` by serializing their actual values (vs. storing the class+id pair used for AR objects).  This allows for DRYing up simple items (e.g. Time values) across multiple `set!` calls without having to resort to direct instance variable manipulation in before(:all) blocks, e.g.
```ruby
set!(:frozen_time) { 7.days.ago }
set!(:old_post) { Timecop.freeze(frozen_time) { create :post } }
set!(:old_like) { Timecop.freeze(frozen_time) { create :like, :likeable => post } }
```
Also, address some rails and rspec deprecations/warnings in internal specs.